### PR TITLE
feat(core): add SM-2 algorithm module

### DIFF
--- a/packages/mychessbook-core/jest.config.js
+++ b/packages/mychessbook-core/jest.config.js
@@ -1,0 +1,4 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  ...require('../../jest.config'),
+};

--- a/packages/mychessbook-core/package.json
+++ b/packages/mychessbook-core/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "mychessbook-core",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "module": "src/index.ts",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "clean": "rimraf dist .turbo",
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "pnpm watch",
+    "format": "biome format --write .",
+    "format:check": "biome ci .",
+    "lint": "eslint .",
+    "lintfix": "eslint . --fix",
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:dev": "jest --watch"
+  },
+  "files": ["dist/**/*"],
+  "devDependencies": {},
+  "dependencies": {}
+}

--- a/packages/mychessbook-core/src/index.ts
+++ b/packages/mychessbook-core/src/index.ts
@@ -1,0 +1,1 @@
+export * from './sm2';

--- a/packages/mychessbook-core/src/sm2.ts
+++ b/packages/mychessbook-core/src/sm2.ts
@@ -1,0 +1,37 @@
+export interface ReviewState {
+  interval: number; // days
+  easeFactor: number;
+  repetitions: number;
+}
+
+export interface ReviewResult extends ReviewState {}
+
+/**
+ * Calculate next spaced repetition values using the SM-2 algorithm.
+ * @param state Previous review state
+ * @param quality Response quality from 0 to 5
+ */
+export function sm2(state: ReviewState, quality: number): ReviewResult {
+  let { interval, easeFactor, repetitions } = state;
+
+  if (quality < 3) {
+    repetitions = 0;
+    interval = 1;
+  } else {
+    if (repetitions === 0) {
+      interval = 1;
+    } else if (repetitions === 1) {
+      interval = 6;
+    } else {
+      interval = Math.round(interval * easeFactor);
+    }
+    repetitions += 1;
+  }
+
+  easeFactor = easeFactor + 0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02);
+  if (easeFactor < 1.3) {
+    easeFactor = 1.3;
+  }
+
+  return { interval, easeFactor, repetitions };
+}

--- a/packages/mychessbook-core/test/sm2.test.ts
+++ b/packages/mychessbook-core/test/sm2.test.ts
@@ -1,0 +1,18 @@
+import { sm2, ReviewState } from '../src';
+
+describe('sm2', () => {
+  it('increments repetition and interval for good quality', () => {
+    const state: ReviewState = { interval: 1, easeFactor: 2.5, repetitions: 1 };
+    const result = sm2(state, 5);
+    expect(result.repetitions).toBe(2);
+    expect(result.interval).toBe(6);
+    expect(result.easeFactor).toBeGreaterThan(state.easeFactor);
+  });
+
+  it('resets repetition on low quality', () => {
+    const state: ReviewState = { interval: 10, easeFactor: 2.5, repetitions: 5 };
+    const result = sm2(state, 2);
+    expect(result.repetitions).toBe(0);
+    expect(result.interval).toBe(1);
+  });
+});

--- a/packages/mychessbook-core/tsconfig.build.json
+++ b/packages/mychessbook-core/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/build.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["test/**", "src/**/__tests__/**"]
+}

--- a/packages/mychessbook-core/tsconfig.json
+++ b/packages/mychessbook-core/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- create new `mychessbook-core` package
- implement `sm2` spaced repetition algorithm
- add basic tests for the algorithm

## Testing
- `npx tsc -p packages/mychessbook-core/tsconfig.build.json` *(fails: Cannot find type definitions)*
- `pnpm test --filter mychessbook-core` *(fails: unable to fetch packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68515fc771748323905ab3cf42f07431